### PR TITLE
Enable ProGuard for Android release builds to decrease APK size

### DIFF
--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -60,6 +60,12 @@ android {
 		buildType.zipAlignEnabled false
 		buildType.signingConfig null
 	}
+
+	buildTypes.release {
+		minifyEnabled true
+		proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+	}
+
 	sourceSets {
 		main {
 			manifest.srcFile 'AndroidManifest.xml'
@@ -106,8 +112,3 @@ android {
 
 //CHUNK_GLOBAL_BEGIN
 //CHUNK_GLOBAL_END
-
-
-
-
-

--- a/platform/android/java/proguard-rules.pro
+++ b/platform/android/java/proguard-rules.pro
@@ -1,0 +1,13 @@
+-dontwarn org.godotengine.godot.**
+
+-keep class org.godotengine.godot.** {*;}
+-keep class * extends java.util.ListResourceBundle {
+   protected java.lang.Object[][] getContents();
+}
+
+-keepnames class * implements android.os.Parcelable {
+   public static final ** CREATOR;
+}
+-keepattributes *Annotation*
+
+-optimizations !code/allocation/variable


### PR DESCRIPTION
I'm sorry if you got notified of this activity. I have next-to-no experience with the site, hence: experimentation. 
Sorry if it has bothered you!
 
...............................

This reduces the size of release APKs by about 300 KB on average.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
