### PR TITLE
Enable single-window mode by default in projects

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2105,7 +2105,7 @@ bool Main::start() {
 		}
 #endif
 
-		bool embed_subwindows = GLOBAL_DEF("display/window/subwindows/embed_subwindows", false);
+		bool embed_subwindows = GLOBAL_DEF("display/window/subwindows/embed_subwindows", true);
 
 		if (single_window || (!project_manager && !editor && embed_subwindows)) {
 			sml->get_root()->set_embed_subwindows_hint(true);


### PR DESCRIPTION
There are many issues with using multiple windows by default:

- Taking screenshots of a specific window will not capture subwindows.
  This also applies when recording a video using tools such as OBS.
- Subwindows may not behave correctly when fullscreen mode is enabled,
  especially if exclusive fullscreen is implemented in the future
  to decrease input lag on Windows.

"Subwindows" is quite general here, and also refers to dropdown menus
(e.g. those spawned by OptionButton) and Control tooltips.

Therefore, it's safer to embed subwindows by default in projects.
Multi-window mode remains the default in the editor.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
