### PR TITLE
Disable Node3D when compiling without 3D and fix disable_3d option

### DIFF
--- a/scene/3d/SCsub
+++ b/scene/3d/SCsub
@@ -2,7 +2,4 @@
 
 Import("env")
 
-if env["disable_3d"]:
-    env.add_source_files(env.scene_sources, "node_3d.cpp")
-else:
-    env.add_source_files(env.scene_sources, "*.cpp")
+env.add_source_files(env.scene_sources, "*.cpp")

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -10,7 +10,8 @@ env.add_source_files(env.scene_sources, "*.cpp")
 # Chain load SCsubs
 SConscript("main/SCsub")
 SConscript("gui/SCsub")
-SConscript("3d/SCsub")
+if not env["disable_3d"]:
+    SConscript("3d/SCsub")
 SConscript("2d/SCsub")
 SConscript("animation/SCsub")
 SConscript("audio/SCsub")

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -90,7 +90,7 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 		ERR_FAIL_COND_V(p_args.size() < 1, ERR_INVALID_DATA);
 		Transform2D transform = p_args[1];
 		scene_tree->get_root()->set_canvas_transform_override(transform);
-
+#ifndef _3D_DISABLED
 	} else if (p_msg == "override_camera_3D:set") {
 		ERR_FAIL_COND_V(p_args.size() < 1, ERR_INVALID_DATA);
 		bool enable = p_args[0];
@@ -109,7 +109,7 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 			scene_tree->get_root()->set_camera_3d_override_orthogonal(size_or_fov, near, far);
 		}
 		scene_tree->get_root()->set_camera_3d_override_transform(transform);
-
+#endif // _3D_DISABLED
 	} else if (p_msg == "set_object_property") {
 		ERR_FAIL_COND_V(p_args.size() < 3, ERR_INVALID_DATA);
 		_set_object_property(p_args[0], p_args[1], p_args[2]);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -499,7 +499,7 @@ bool SceneTree::process(double p_time) {
 	_call_idle_callbacks();
 
 #ifdef TOOLS_ENABLED
-
+#ifndef _3D_DISABLED
 	if (Engine::get_singleton()->is_editor_hint()) {
 		//simple hack to reload fallback environment if it changed from editor
 		String env_path = ProjectSettings::get_singleton()->get(SNAME("rendering/environment/defaults/default_environment"));
@@ -522,8 +522,8 @@ bool SceneTree::process(double p_time) {
 			get_root()->get_world_3d()->set_fallback_environment(fallback);
 		}
 	}
-
-#endif
+#endif // _3D_DISABLED
+#endif // TOOLS_ENABLED
 
 	return _quit;
 }
@@ -1333,15 +1333,16 @@ SceneTree::SceneTree() {
 
 	root = memnew(Window);
 	root->set_name("root");
+#ifndef _3D_DISABLED
 	if (!root->get_world_3d().is_valid()) {
 		root->set_world_3d(Ref<World3D>(memnew(World3D)));
 	}
+	root->set_as_audio_listener_3d(true);
+#endif // _3D_DISABLED
 
 	// Initialize network state.
 	set_multiplayer(Ref<MultiplayerAPI>(memnew(MultiplayerAPI)));
 
-	//root->set_world_2d( Ref<World2D>( memnew( World2D )));
-	root->set_as_audio_listener_3d(true);
 	root->set_as_audio_listener_2d(true);
 	current_scene = nullptr;
 
@@ -1397,6 +1398,7 @@ SceneTree::SceneTree() {
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/2d/sdf/oversize", PropertyInfo(Variant::INT, "rendering/2d/sdf/oversize", PROPERTY_HINT_ENUM, "100%,120%,150%,200%"));
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/2d/sdf/scale", PropertyInfo(Variant::INT, "rendering/2d/sdf/scale", PROPERTY_HINT_ENUM, "100%,50%,25%"));
 
+#ifndef _3D_DISABLED
 	{ // Load default fallback environment.
 		// Get possible extensions.
 		List<String> exts;
@@ -1428,6 +1430,7 @@ SceneTree::SceneTree() {
 			}
 		}
 	}
+#endif // _3D_DISABLED
 
 	root->set_physics_object_picking(GLOBAL_DEF("physics/common/enable_object_picking", true));
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -36,10 +36,12 @@
 #include "core/templates/pair.h"
 #include "scene/2d/camera_2d.h"
 #include "scene/2d/collision_object_2d.h"
+#ifndef _3D_DISABLED
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/collision_object_3d.h"
 #include "scene/3d/listener_3d.h"
 #include "scene/3d/world_environment.h"
+#endif // _3D_DISABLED
 #include "scene/gui/control.h"
 #include "scene/gui/label.h"
 #include "scene/gui/popup.h"
@@ -377,14 +379,17 @@ void Viewport::_notification(int p_what) {
 			current_canvas = find_world_2d()->get_canvas();
 			RenderingServer::get_singleton()->viewport_attach_canvas(viewport, current_canvas);
 			_update_listener_2d();
+#ifndef _3D_DISABLED
 			RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
 			_update_listener_3d();
+#endif // _3D_DISABLED
 
 			add_to_group("_viewports");
 			if (get_tree()->is_debugging_collisions_hint()) {
 				PhysicsServer2D::get_singleton()->space_set_debug_contacts(find_world_2d()->get_space(), get_tree()->get_collision_debug_contact_count());
 				contact_2d_debug = RenderingServer::get_singleton()->canvas_item_create();
 				RenderingServer::get_singleton()->canvas_item_set_parent(contact_2d_debug, find_world_2d()->get_canvas());
+#ifndef _3D_DISABLED
 				PhysicsServer3D::get_singleton()->space_set_debug_contacts(find_world_3d()->get_space(), get_tree()->get_collision_debug_contact_count());
 				contact_3d_debug_multimesh = RenderingServer::get_singleton()->multimesh_create();
 				RenderingServer::get_singleton()->multimesh_allocate_data(contact_3d_debug_multimesh, get_tree()->get_collision_debug_contact_count(), RS::MULTIMESH_TRANSFORM_3D, true);
@@ -394,10 +399,12 @@ void Viewport::_notification(int p_what) {
 				RenderingServer::get_singleton()->instance_set_base(contact_3d_debug_instance, contact_3d_debug_multimesh);
 				RenderingServer::get_singleton()->instance_set_scenario(contact_3d_debug_instance, find_world_3d()->get_scenario());
 				//RenderingServer::get_singleton()->instance_geometry_set_flag(contact_3d_debug_instance, RS::INSTANCE_FLAG_VISIBLE_IN_ALL_ROOMS, true);
+#endif // _3D_DISABLED
 			}
 
 		} break;
 		case NOTIFICATION_READY: {
+#ifndef _3D_DISABLED
 			if (listener_3d_set.size() && !listener_3d) {
 				Listener3D *first = nullptr;
 				for (Set<Listener3D *>::Element *E = listener_3d_set.front(); E; E = E->next()) {
@@ -424,7 +431,7 @@ void Viewport::_notification(int p_what) {
 					first->make_current();
 				}
 			}
-
+#endif // _3D_DISABLED
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			_gui_cancel_tooltip();
@@ -462,6 +469,7 @@ void Viewport::_notification(int p_what) {
 					RenderingServer::get_singleton()->canvas_item_add_rect(contact_2d_debug, Rect2(points[i] - Vector2(2, 2), Vector2(5, 5)), ccol);
 				}
 			}
+#ifndef _3D_DISABLED
 			if (get_tree()->is_debugging_collisions_hint() && contact_3d_debug_multimesh.is_valid()) {
 				Vector<Vector3> points = PhysicsServer3D::get_singleton()->space_get_contacts(find_world_3d()->get_space());
 				int point_count = PhysicsServer3D::get_singleton()->space_get_contact_count(find_world_3d()->get_space());
@@ -474,6 +482,7 @@ void Viewport::_notification(int p_what) {
 					RS::get_singleton()->multimesh_instance_set_transform(contact_3d_debug_multimesh, i, point_transform);
 				}
 			}
+#endif // _3D_DISABLED
 		} break;
 		case NOTIFICATION_WM_MOUSE_EXIT: {
 			_drop_physics_mouseover();
@@ -506,10 +515,6 @@ void Viewport::_process_picking() {
 
 	_drop_physics_mouseover(true);
 
-	Vector2 last_pos(1e20, 1e20);
-	CollisionObject3D *last_object = nullptr;
-	ObjectID last_id;
-	PhysicsDirectSpaceState3D::RayResult result;
 	PhysicsDirectSpaceState2D *ss2d = PhysicsServer2D::get_singleton()->space_get_direct_state(find_world_2d()->get_space());
 
 	if (physics_has_last_mousepos) {
@@ -669,6 +674,11 @@ void Viewport::_process_picking() {
 			}
 		}
 
+#ifndef _3D_DISABLED
+		Vector2 last_pos(1e20, 1e20);
+		CollisionObject3D *last_object = nullptr;
+		ObjectID last_id;
+		PhysicsDirectSpaceState3D::RayResult result;
 		bool captured = false;
 
 		if (physics_object_capture.is_valid()) {
@@ -741,6 +751,7 @@ void Viewport::_process_picking() {
 				last_pos = pos;
 			}
 		}
+#endif // _3D_DISABLED
 	}
 }
 
@@ -2204,6 +2215,7 @@ void Viewport::_drop_physics_mouseover(bool p_paused_only) {
 
 	_cleanup_mouseover_colliders(true, p_paused_only);
 
+#ifndef _3D_DISABLED
 	if (physics_object_over.is_valid()) {
 		CollisionObject3D *co = Object::cast_to<CollisionObject3D>(ObjectDB::get_instance(physics_object_over));
 		if (co) {
@@ -2214,6 +2226,7 @@ void Viewport::_drop_physics_mouseover(bool p_paused_only) {
 			}
 		}
 	}
+#endif // _3D_DISABLED
 }
 
 void Viewport::_cleanup_mouseover_colliders(bool p_clean_all_frames, bool p_paused_only, uint64_t p_frame_reference) {
@@ -3063,6 +3076,7 @@ Viewport::SDFScale Viewport::get_sdf_scale() const {
 	return sdf_scale;
 }
 
+#ifndef _3D_DISABLED
 Listener3D *Viewport::get_listener_3d() const {
 	return listener_3d;
 }
@@ -3460,6 +3474,7 @@ void Viewport::set_use_xr(bool p_use_xr) {
 bool Viewport::is_using_xr() {
 	return use_xr;
 }
+#endif // _3D_DISABLED
 
 void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_world_2d", "world_2d"), &Viewport::set_world_2d);
@@ -3565,6 +3580,7 @@ void Viewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_process_picking"), &Viewport::_process_picking);
 
+#ifndef _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("set_world_3d", "world_3d"), &Viewport::set_world_3d);
 	ClassDB::bind_method(D_METHOD("get_world_3d"), &Viewport::get_world_3d);
 	ClassDB::bind_method(D_METHOD("find_world_3d"), &Viewport::find_world_3d);
@@ -3587,6 +3603,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "audio_listener_enable_3d"), "set_as_audio_listener_3d", "is_audio_listener_3d");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "own_world_3d"), "set_use_own_world_3d", "is_using_own_world_3d");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "world_3d", PROPERTY_HINT_RESOURCE_TYPE, "World3D"), "set_world_3d", "get_world_3d");
+#endif // _3D_DISABLED
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "world_2d", PROPERTY_HINT_RESOURCE_TYPE, "World2D", PROPERTY_USAGE_NONE), "set_world_2d", "get_world_2d");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "transparent_bg"), "set_transparent_background", "has_transparent_background");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "handle_input_locally"), "set_handle_input_locally", "is_handling_input_locally");

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -34,10 +34,12 @@
 #include "scene/main/node.h"
 #include "scene/resources/texture.h"
 
+#ifndef _3D_DISABLED
 class Camera3D;
 class CollisionObject3D;
 class Listener3D;
 class World3D;
+#endif // _3D_DISABLED
 
 class Camera2D;
 class CanvasItem;
@@ -573,6 +575,7 @@ public:
 
 	void pass_mouse_focus_to(Viewport *p_viewport, Control *p_control);
 
+#ifndef _3D_DISABLED
 	bool use_xr = false;
 	friend class Listener3D;
 	Listener3D *listener_3d = nullptr;
@@ -644,6 +647,7 @@ public:
 
 	void set_use_xr(bool p_use_xr);
 	bool is_using_xr();
+#endif // _3D_DISABLED
 
 	Viewport();
 	~Viewport();

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -162,12 +162,14 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 				}
 				WARN_PRINT(vformat("Node %s of type %s cannot be created. A placeholder will be created instead.", snames[n.name], snames[n.type]).ascii().get_data());
 				if (n.parent >= 0 && n.parent < nc && ret_nodes[n.parent]) {
-					if (Object::cast_to<Node3D>(ret_nodes[n.parent])) {
-						obj = memnew(Node3D);
-					} else if (Object::cast_to<Control>(ret_nodes[n.parent])) {
+					if (Object::cast_to<Control>(ret_nodes[n.parent])) {
 						obj = memnew(Control);
 					} else if (Object::cast_to<Node2D>(ret_nodes[n.parent])) {
 						obj = memnew(Node2D);
+#ifndef _3D_DISABLED
+					} else if (Object::cast_to<Node3D>(ret_nodes[n.parent])) {
+						obj = memnew(Node3D);
+#endif // _3D_DISABLED
 					}
 				}
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
