### PR TITLE
[Net] Fix bogus FileAccessNetwork deconstructor.

### DIFF
--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -491,7 +491,6 @@ FileAccessNetwork::~FileAccessNetwork() {
 
 	FileAccessNetworkClient *nc = FileAccessNetworkClient::singleton;
 	nc->lock_mutex();
-	id = nc->last_id++;
 	nc->accesses.erase(id);
 	nc->unlock_mutex();
 }


### PR DESCRIPTION
Now correctly erases old instances.
The code will likely need overhaul anyway to be usable.
It doesn't apply to editor runs, there's a bunch of inconsistencies on
how to clients are handled, and I don't really understand why multiple
instances are created for a single client/server.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
