### PR TITLE
Add a FPS limit applied when the project window is unfocused or minim…

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -293,6 +293,11 @@
 		<member name="application/run/main_scene" type="String" setter="" getter="" default="&quot;&quot;">
 			Path to the main scene file that will be loaded when the project runs.
 		</member>
+		<member name="application/run/max_fps_when_unfocused" type="int" setter="" getter="" default="10">
+			If set to a value above [code]0[/code], applies a FPS limit while the project window is unfocused. The default value is optimized to reduce power usage while the project window is unfocused at the cost of smoothness. Since minimizing the window will consider the window as unfocused, this FPS limit also applies when the project window is minimized.
+			Set [member debug/settings/fps/force_fps] to value above [code]0[/code] to apply a FPS limit while the window is focused.
+			[b]Note:[/b] To change the FPS limit while the project is running, set [member Engine.target_fps] instead.
+		</member>
 		<member name="audio/buses/channel_disable_threshold_db" type="float" setter="" getter="" default="-60.0">
 			Audio buses will disable automatically when sound goes below a given dB threshold for a given time. This saves CPU as effects assigned to that bus will no longer do any processing.
 		</member>
@@ -442,9 +447,11 @@
 			Message to be displayed before the backtrace when the engine crashes.
 		</member>
 		<member name="debug/settings/fps/force_fps" type="int" setter="" getter="" default="0">
-			Maximum number of frames per second allowed. The actual number of frames per second may still be below this value if the game is lagging.
+			If set to a value above [code]0[/code], limits the maximum number of frames per second allowed. The actual number of frames per second may still be below this value if the game is lagging.
 			If [member display/window/vsync/use_vsync] is enabled, it takes precedence and the forced FPS number cannot exceed the monitor's refresh rate.
 			This setting is therefore mostly relevant for lowering the maximum FPS below VSync, e.g. to perform non-real-time rendering of static frames, or test the project under lag conditions.
+			See also [member application/run/max_fps_when_unfocused], which limits FPS when the project window is unfocused (and is enabled by default).
+			[b]Note:[/b] To change the FPS limit while the project is running, set [member Engine.target_fps] instead.
 		</member>
 		<member name="debug/settings/gdscript/max_call_stack" type="int" setter="" getter="" default="1024">
 			Maximum call stack allowed for debugging GDScript.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1382,6 +1382,13 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 					PROPERTY_HINT_RANGE,
 					"0,33200,1,or_greater")); // No negative numbers
 
+	GLOBAL_DEF("application/run/max_fps_when_unfocused", 10);
+	ProjectSettings::get_singleton()->set_custom_property_info("application/run/max_fps_when_unfocused",
+			PropertyInfo(Variant::INT,
+					"application/run/max_fps_when_unfocused",
+					PROPERTY_HINT_RANGE,
+					"0,120,1,or_greater")); // No negative numbers
+
 	GLOBAL_DEF("display/window/ios/hide_home_indicator", true);
 	GLOBAL_DEF("input_devices/pointing/ios/touch_delay", 0.150);
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -566,14 +566,34 @@ void SceneTree::_notification(int p_notification) {
 				get_root()->propagate_notification(p_notification);
 			}
 		} break;
+		case NOTIFICATION_APPLICATION_FOCUS_IN: {
+			// If the unfocused FPS limit is set to 0, don't restore it at all. Otherwise,
+			// an user-applied FPS limit would be set back to the `force_fps` value when the project window is refocused.
+			if (!Engine::get_singleton()->is_editor_hint() && int(GLOBAL_GET("application/run/max_fps_when_unfocused")) >= 1) {
+				// Restore the previous FPS limit.
+				Engine::get_singleton()->set_target_fps(previous_target_fps);
+			}
+
+			get_root()->propagate_notification(p_notification);
+		} break;
+		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
+			// If the unfocused FPS limit is set to 0, don't apply it at all. Otherwise,
+			// an user-applied FPS limit would be removed while the project window is unfocused.
+			if (!Engine::get_singleton()->is_editor_hint() && int(GLOBAL_GET("application/run/max_fps_when_unfocused")) >= 1) {
+				// Apply a FPS limit to reduce power usage while the window is unfocused
+				// (or minimized, since the window is considered to be unfocused when minimized).
+				previous_target_fps = Engine::get_singleton()->get_target_fps();
+				Engine::get_singleton()->set_target_fps(int(GLOBAL_GET("application/run/max_fps_when_unfocused")));
+			}
+
+			get_root()->propagate_notification(p_notification);
+		} break;
 		case NOTIFICATION_OS_MEMORY_WARNING:
 		case NOTIFICATION_OS_IME_UPDATE:
 		case NOTIFICATION_WM_ABOUT:
 		case NOTIFICATION_CRASH:
 		case NOTIFICATION_APPLICATION_RESUMED:
-		case NOTIFICATION_APPLICATION_PAUSED:
-		case NOTIFICATION_APPLICATION_FOCUS_IN:
-		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
+		case NOTIFICATION_APPLICATION_PAUSED: {
 			get_root()->propagate_notification(p_notification); //pass these to nodes, since they are mirrored
 		} break;
 
@@ -1350,6 +1370,8 @@ SceneTree::SceneTree() {
 	GLOBAL_DEF("debug/shapes/collision/draw_2d_outlines", true);
 
 	Math::randomize();
+
+	previous_target_fps = GLOBAL_GET("debug/settings/fps/force_fps");
 
 	// Create with mainloop.
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -108,6 +108,7 @@ private:
 	StringName node_renamed_name = "node_renamed";
 
 	int64_t current_frame = 0;
+	int previous_target_fps = 0;
 	int node_count = 0;
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
…ized

This helps decrease power usage while the project window is unfocused
or minimized.

The default FPS limit is 10. It can be disabled by setting the
`application/run/max_fps_when_unfocused` project setting to 0.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
